### PR TITLE
Properly handle OSError + Logging Proposal

### DIFF
--- a/config.py
+++ b/config.py
@@ -19,7 +19,8 @@ def get_unused_port(range_start: int, range_stop: int) -> int | OSError:
 
 
 class Config:
-    def __init__(self):
+    def __init__(self, log: logging.Logger):
+        self._log = log
         self.APP_NAME = 'VRChatOWOSuit'
         self.current_config = None
 
@@ -47,7 +48,8 @@ class Config:
         }
 
     def get_by_key(self, key: str):
-        return self.current_config.get(key)
+        if self.current_config is not None:
+            return self.current_config.get(key)
 
     def update(self, key: str, nextValue):
         if (key in self.current_config):

--- a/config.py
+++ b/config.py
@@ -1,14 +1,33 @@
-import json
+import logging
+import socket
+
 import params
 import os
 import json
 
 
+def get_unused_port(range_start: int, range_stop: int) -> int | OSError:
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    for i in range(range_start, range_stop):
+        try:
+            s.bind(('127.0.0.1', i))
+            s.close()
+            return i
+        except OSError as err:
+            if i == range_stop - 1:
+                raise err
+
+
 class Config:
     def __init__(self):
         self.APP_NAME = 'VRChatOWOSuit'
-        self.default_config = {
-            "server_port": 9001,
+        self.current_config = None
+
+    @property
+    def default_config(self):
+        server_port = get_unused_port(9001, 9010)
+        return {
+            "server_port": server_port,
             "owo_ip": "",
             "should_detect_ip": True,
             "should_connect_on_startup": False,
@@ -26,7 +45,6 @@ class Config:
                 params.owo_suit_Lumbar_R: 60,
             }
         }
-        self.current_config = None
 
     def get_by_key(self, key: str):
         return self.current_config.get(key)

--- a/main.py
+++ b/main.py
@@ -4,17 +4,23 @@ from pythonosc.dispatcher import Dispatcher
 from pythonosc.osc_server import ThreadingOSCUDPServer
 from owo_suit import OWOSuit
 from config import Config
-from gui import Gui
+from gui import Gui, GuiLogger
 import os
+import logging
 
-
-gui = None
+log = logging.getLogger("vrc-owo-suit")
+console_handler = logging.StreamHandler()
+console_handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
+console_handler.setLevel(logging.WARNING)
+log.addHandler(console_handler)
+cfg = Config(log.getChild("Config"))
+logo_path = os.path.abspath(os.path.join(os.path.dirname(__file__), './img/logo.png'))
+gui = Gui(config=cfg, window_width=550, window_height=1000, logo_path=logo_path, log=log.getChild("GUI"))
+gui_logger = GuiLogger(gui)
+gui_logger.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
+log.addHandler(gui_logger)
 try:
-    cfg = Config()
     cfg.init()
-    logo_path = os.path.abspath(os.path.join(os.path.dirname(__file__), './img/logo.png'))
-    gui = Gui(config=cfg, window_width=550,
-              window_height=1000, logo_path=logo_path)
     gui.init()
     owo_suit = OWOSuit(config=cfg, gui=gui)
     owo_suit.init()
@@ -31,9 +37,14 @@ try:
                      daemon=True).start()
     gui.run()
 except KeyboardInterrupt:
-    print("Shutting Down...\n")
-except OSError:
-    pass
+    log.warning("Shutting Down...\n")
+except OSError as e:
+    log.error("The OSC port (UDP) is already taken. Please change the port or close the other application listening to "
+              "that port. If you want to run multiple OSC applications, consider running VOR "
+              "(https://github.com/SutekhVRC/VOR/tree/main)")
+    log.error("Got OSError during startup: %s" % e.strerror)
+    gui.init()  # Make sure the GUI is initialized, even if it had an error before starting the GUI
+    gui.run()
 finally:
     if gui is not None:
         gui.cleanup()


### PR DESCRIPTION
This is my PR According to #11.

Changes:
- It adds the ability to use the python logging module for logging inside the GUI
- If the application runs into an error during startup, it will try to start the UI anyways and display the error message there. If the causing error is inside the UI, it will still be logged to console
- The default port is now chosen by trying to bind to a range of ports, starting from 9001 until 9009. If it cannot bind any port, a proper error message will be shown.

This is not the optimal solution, so i will probably follow up with another PR. Reasons:
- The change to the logging infrastructure is not yet adapted in most of the code. Most of the logging still happens only in the GUI or in console
- If the application fails to start, it may be counterintuitive to just load it up with default values. People might wonder why it is not working, because everything looks normal (except for the logging)